### PR TITLE
Added Codeforces Rating Boost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+node_modules
+README.md
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ Views folder: EJS files that are rendered to users
 
 To run this locally, download the files, install Node.js and use npm to install the necessary packages. Then, run:
 ```node app.js```.
-<<<<<<< HEAD
 
-Current Developers: Gabriel Xu, Johnny Liu, and Daniel Qiu
+Developers (contact if there are any questions/issues):
+2023-2024: Gabriel Xu, Daniel Qiu, Johnny Liu
+2022-2023: Johnny Liu, Daniel Qiu
 
-=======
-
-Current Developers: Gabriel Xu, Johnny Liu, and Daniel Qiu
->>>>>>> 959371d94876ba2b40593bd7df5eb02c51da9bdf

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To run this locally, download the files, install Node.js and use npm to install 
 ```node app.js```.
 
 Developers (contact if there are any questions/issues):
+
 2023-2024: Gabriel Xu, Daniel Qiu, Johnny Liu
+
 2022-2023: Johnny Liu, Daniel Qiu
 


### PR DESCRIPTION
This pull request adds a new function (updateRating) to update a user's Rating parameter by adding 1/10 of the rating gain (on codeforces) from the the most recent contest. This functionality is integrated with the Codeforces API to fetch the most recent contest rating change for a given user. Here's a simple outline of the process:

1. Fetching User's Codeforces Username:
- Retrieve the user's Codeforces username and current rating from the database (this would need further changes to the existing structure of the database).
2. Fetching Rating Changes from Codeforces API:
- Use Codeforces API to get the user's rating change from recent contests.
- Indentify the rating change from the most recent contest
3. Updating the User's Rating:
- If the user gained rating in the most recent contest, update the user's Rating in the database by adding 1/10 of the rating gain

Other tid bids:
I couldn't actually test the functionality of the code I created since I couldn't figure out how to get past Oauth and that I realized that took up too much of my time so I unfortunately had to just write down code and hope it works, but if I had more time I would definately test the functionality of the code I added rigourously and perhaps add other functionality. Also the choice of updating a user's rating by 1/10 of rating change is something arbitrary and can be changed to whatever would be deemed a balanced amount.